### PR TITLE
Changing the delay pattern to a mutable reference based one

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bno055"
 description = "Bosch Sensortec BNO055 9-axis IMU driver"
 version = "0.1.5"
-authors = ["Eugene P. <eupn@protonmail.com>"]
+authors = ["Eugene P. <eupn@protonmail.com>", "Henrik B. <hargonix@gmail.com>"]
 repository = "https://github.com/eupn/bno055"
 edition = "2018"
 categories = [


### PR DESCRIPTION
As delay is based upon singletons in for example all of the stm32 HAL implementations and other objects (or the user himself) might want to make use of it as well, taking ownership of a delay object is not acceptable imho. Thus this PR changes it so the user always has to pass a mutable reference to a delay object which yes makes the code for this sensor a bit longer but at least the user can now use the delay object in multiple places in a safe way. (and I allowed myself to add myself as an author)

If you should publish this (which I hope you do as I'd like to use this without having to define a git dependency) you'd have to increment the major version number as this introduces a fair bunch of breaking changes.