### PR TITLE
Adds fuzzing targets for calibration

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,3 +40,8 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         args: --all-features
+    - name: Fuzz
+      run: |
+        cargo install cargo-fuzz
+        cargo fuzz run init -- -max_total_time=900
+        cargo fuzz run calibrate -- -max_total_time=1800

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "bno055-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+embedded-hal-fuzz = "0.1.2"
+embedded-hal = "0.2.7"
+
+[dependencies.bno055]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "init"
+path = "fuzz_targets/init.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "calibrate"
+path = "fuzz_targets/calibrate.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/calibrate.rs
+++ b/fuzz/fuzz_targets/calibrate.rs
@@ -1,0 +1,52 @@
+#![no_main]
+/// This is a modified version of the 'example' project optimized for fuzzing.
+
+use libfuzzer_sys::fuzz_target;
+
+use embedded_hal::blocking::delay::DelayMs;
+use embedded_hal_fuzz as hal_fuzz;
+use bno055::{BNO055OperationMode, Bno055};
+
+struct Delay {}
+
+impl Delay { pub fn new() -> Self { Delay{ } }}
+
+impl DelayMs<u16> for Delay {
+   fn delay_ms(&mut self, _ms: u16) {
+       // no-op, go as fast as possible for fuzzing
+   }
+}
+
+type I2cError = ();
+
+fuzz_target!(|data: &[u8]| {
+    use hal_fuzz::shared_data::FuzzData;
+    let data = FuzzData::new(data);
+    let i2c: hal_fuzz::i2c::I2cFuzz<'_, I2cError> = hal_fuzz::i2c::I2cFuzz::new(data);
+    let mut delay = Delay::new();
+
+    let mut imu = Bno055::new(i2c).with_alternative_address();
+
+    let _ = imu.init(&mut delay);
+
+    let _ = imu.set_mode(BNO055OperationMode::NDOF, &mut delay);
+
+    let _ = imu.get_calibration_status();
+
+    if !imu.is_fully_calibrated().is_ok() {
+        let _ = imu.get_calibration_status();
+    }
+
+    if let Ok(calib) = imu.calibration_profile(&mut delay) {
+        let _ = imu.set_calibration_profile(calib, &mut delay);
+    }
+
+    // Quaternion; due to a bug in the BNO055, this is recommended over Euler Angles
+    let _quaternion = imu.quaternion();
+
+    // Euler angles, directly read
+    let _euler =  imu.euler_angles();
+
+    // Temperature.
+    let _temp = imu.temperature();
+});

--- a/fuzz/fuzz_targets/init.rs
+++ b/fuzz/fuzz_targets/init.rs
@@ -1,0 +1,31 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use embedded_hal::blocking::delay::DelayMs;
+use embedded_hal_fuzz as hal_fuzz;
+
+struct Delay {}
+
+impl Delay { pub fn new() -> Self { Delay{ } }}
+
+impl DelayMs<u16> for Delay {
+   fn delay_ms(&mut self, _ms: u16) {
+       // no-op, go as fast as possible for fuzzing
+   }
+}
+
+type I2cError = ();
+
+fuzz_target!(|data: &[u8]| {
+    use hal_fuzz::shared_data::FuzzData;
+    let data = FuzzData::new(data);
+    let i2c: hal_fuzz::i2c::I2cFuzz<'_, I2cError> = hal_fuzz::i2c::I2cFuzz::new(data);
+    let mut delay = Delay::new();
+
+    // Init BNO055 IMU
+    let mut imu = bno055::Bno055::new(i2c);
+
+    // Discard the result as we only care about it it crashes not if there
+    // is an error.
+    let _ = imu.init(&mut delay);
+});


### PR DESCRIPTION
This is a great driver! I've just been fuzz testing it so I can be confident it's not going to crash on me. Haven't found any bugs so far, so great work it seems to be a lot more stable than my own drivers. Thought I'd contribute the tests back if you feel inclined to use them.

Quickstart on usage;
1. `cargo install cargo-fuzz`
2. `cargo +nightly fuzz run calibrate`

I've added the fuzzing to the CI. At the moment, the fuzzing will run for at most 45min, after which it'll timeout. Happy to change those timeouts if you feel strongly about them.

To really get the most out of these tests I'd recommend looking into the cluster-fuzz-lite GitHub action. But that's not something that I can set up on your behalf, as you'll need to create a separate repository to store the fuzz corpus.