### PR TITLE
Fix quaternion mapping.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,12 +334,15 @@ where
 
             let scale = 1.0 / ((1 << 14) as f32);
 
-            let quat = mint::Quaternion::from([
-                w as f32 * scale,
-                x as f32 * scale,
-                y as f32 * scale,
-                z as f32 * scale,
-            ]);
+            let x = x as f32 * scale;
+            let y = y as f32 * scale;
+            let z = z as f32 * scale;
+            let w = w as f32 * scale;
+
+            let quat = mint::Quaternion {
+                v: mint::Vector3 { x, y, z },
+                s: w,
+            };
 
             Ok(quat)
         } else {


### PR DESCRIPTION
I'm using the quaternion output from the sensor with an esp32c6 and I noticed that the order of the data is wrong.

If I'm reading the mint docs correctly, the order should be x, y, z, w if building the Quat from an array. I switched to explicitly constructing the Quat so it's clearer how the fields are mapped.

Tested with hardware and now the sensor is reacting how I would expect.

I also had to disable the default features for the num-traits crate so that it would compile for a no_std environment.