### PR TITLE
feat: add defmt and add rust-version (MSRV) of 1.62

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,38 +10,58 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  lints-and-checks:
+    name: Lints and checks
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+            components: rustfmt, clippy, rust-docs
+
+      - name: Rustfmt lints
+        run: cargo fmt --all -- --check
+
+      - name: Clippy lints
+        run: cargo clippy --no-deps -- -D warnings
+
+      - name: Build docs
+        run: RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+          - nightly
+          - "1.60" # MSRV
 
     steps:
-    - name: Install Rust (thumbv7em)
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly
-        override: true
-        target: thumbv7em-none-eabihf
-        components: clippy
-    - name: Checkout Sources
-      uses: actions/checkout@v2
-    - name: Build - default features
-      run: cargo build
-    - name: Build - std
-      run: cargo build --features "std"
-    - name: Build - serde
-      run: cargo build --features "serde"
-    - name: Build - examples
-      run: cargo build --examples
-    - name: Test - docs
-      run: cargo test --doc
-    - name: Clippy
-      uses: actions-rs/clippy-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: --all-features
-    - name: Fuzz
-      run: |
-        cargo install cargo-fuzz
-        cargo fuzz run init -- -max_total_time=900
-        cargo fuzz run calibrate -- -max_total_time=1800
+      - name: Checkout Sources
+        uses: actions/checkout@v4
+      - name: Install Rust (thumbv7em)
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          target: thumbv7em-none-eabihf
+      - name: Build - default features
+        run: cargo build
+      - name: Build - std
+        run: cargo build --features "std"
+      - name: Build - serde
+        run: cargo build --features "serde"
+      - name: Build - defmt-03
+        run: cargo build --features "defmt-03"
+      - name: Build - examples
+        run: cargo build --examples
+      - name: Run tests
+        run: cargo test
+      - name: Fuzz
+        run: |
+          cargo install cargo-fuzz
+          cargo fuzz run init -- -max_total_time=900
+          cargo fuzz run calibrate -- -max_total_time=1800

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,8 +60,13 @@ jobs:
         run: cargo build --examples
       - name: Run tests
         run: cargo test
-      - name: Fuzz
+      - name: Install cargo-fuzz
+        # pre-build binaries
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-fuzz
+      - name: Fuzz (nightly only)
+        if: ${{ matrix.rust == 'nightly' }}
         run: |
-          cargo install cargo-fuzz
-          cargo fuzz run init -- -max_total_time=900
-          cargo fuzz run calibrate -- -max_total_time=1800
+          cargo +nightly fuzz run init -- -max_total_time=900
+          cargo +nightly fuzz run calibrate -- -max_total_time=1800

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.60" # MSRV
+          - "1.65" # MSRV
 
     steps:
       - name: Checkout Sources

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ keywords = [
 license-file = "LICENSE"
 readme = "README.md"
 
-# `dep:...` in features is only available from 1.60 on
-rust-version = "1.60"
+# linux-embedded-hal requires 1.65 because of nix
+rust-version = "1.65"
 
 [dependencies]
 byteorder = { version = "1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ embedded-hal = { version = "1.0" }
 default = []
 std = []
 
-defmt-03 = ["dep:defmt"]
+defmt-03 = ["dep:defmt", "embedded-hal/defmt-03"]
 serde = ["dep:serde", "mint/serde"]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ keywords = [
 license-file = "LICENSE"
 readme = "README.md"
 
+# `dep:...` in features is only available from 1.60 on
+rust-version = "1.60"
+
 [dependencies]
 byteorder = { version = "1", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
@@ -25,6 +28,8 @@ bitflags = "1"
 num-traits = "0.2.15"
 num-derive = "0.3.3"
 
+defmt = { version = "0.3", optional = true }
+
 [dependencies.embedded-hal]
 version = "0.2.2"
 features = ["unproven"]
@@ -32,6 +37,9 @@ features = ["unproven"]
 [features]
 default = []
 std = []
+
+defmt-03 = ["dep:defmt"]
+serde = ["dep:serde", "mint/serde"]
 
 [dev-dependencies]
 linux-embedded-hal = "0.3"

--- a/examples/calibrate.rs
+++ b/examples/calibrate.rs
@@ -6,7 +6,8 @@ fn main() {
     let dev = I2cdev::new("/dev/i2c-0").unwrap();
     let mut delay = Delay {};
     let mut imu = Bno055::new(dev).with_alternative_address();
-    imu.init(&mut delay).expect("An error occurred while building the IMU");
+    imu.init(&mut delay)
+        .expect("An error occurred while building the IMU");
 
     imu.set_mode(BNO055OperationMode::NDOF, &mut delay)
         .expect("An error occurred while setting the IMU mode");

--- a/src/acc_config.rs
+++ b/src/acc_config.rs
@@ -6,6 +6,7 @@ const ACC_BANDWIDTH_MASK: u8 = 0b000_111_00;
 const ACC_OPERATION_MODE_MASK: u8 = 0b111_000_00;
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum Error {
     BadAccGRange,
     BadAccBandwidth,
@@ -13,6 +14,7 @@ pub enum Error {
 }
 
 #[derive(Debug, Clone, Copy, FromPrimitive)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[repr(u8)]
 pub enum AccGRange {
     G2 = 0b000_000_00,
@@ -22,6 +24,7 @@ pub enum AccGRange {
 }
 
 #[derive(Debug, Clone, Copy, FromPrimitive)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[repr(u8)]
 pub enum AccBandwidth {
     Hz7_81 = 0b000_000_00,
@@ -35,6 +38,7 @@ pub enum AccBandwidth {
 }
 
 #[derive(Debug, Clone, Copy, FromPrimitive)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[repr(u8)]
 pub enum AccOperationMode {
     Normal = 0b000_000_00,
@@ -46,6 +50,7 @@ pub enum AccOperationMode {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct AccConfig {
     g_range: AccGRange,
     bandwidth: AccBandwidth,

--- a/src/acc_config.rs
+++ b/src/acc_config.rs
@@ -1,12 +1,16 @@
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 
+#[allow(clippy::unusual_byte_groupings)]
 const ACC_G_RANGE_MASK: u8 = 0b000_000_11;
+#[allow(clippy::unusual_byte_groupings)]
 const ACC_BANDWIDTH_MASK: u8 = 0b000_111_00;
+#[allow(clippy::unusual_byte_groupings)]
 const ACC_OPERATION_MODE_MASK: u8 = 0b111_000_00;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[allow(clippy::enum_variant_names)]
 pub enum Error {
     BadAccGRange,
     BadAccBandwidth,
@@ -16,6 +20,7 @@ pub enum Error {
 #[derive(Debug, Clone, Copy, FromPrimitive)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[repr(u8)]
+#[allow(clippy::unusual_byte_groupings)]
 pub enum AccGRange {
     G2 = 0b000_000_00,
     G4 = 0b000_000_01,
@@ -26,6 +31,7 @@ pub enum AccGRange {
 #[derive(Debug, Clone, Copy, FromPrimitive)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[repr(u8)]
+#[allow(clippy::unusual_byte_groupings)]
 pub enum AccBandwidth {
     Hz7_81 = 0b000_000_00,
     Hz15_63 = 0b000_001_00,
@@ -40,6 +46,7 @@ pub enum AccBandwidth {
 #[derive(Debug, Clone, Copy, FromPrimitive)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[repr(u8)]
+#[allow(clippy::unusual_byte_groupings)]
 pub enum AccOperationMode {
     Normal = 0b000_000_00,
     Suspend = 0b001_000_00,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,11 @@ use embedded_hal::{
     i2c::{I2c, SevenBitAddress},
 };
 
+#[cfg(not(feature = "defmt-03"))]
 use bitflags::bitflags;
+#[cfg(feature = "defmt-03")]
+use defmt::bitflags;
+
 use byteorder::{ByteOrder, LittleEndian};
 pub use mint;
 #[cfg(feature = "serde")]
@@ -39,6 +43,7 @@ pub enum Error<E> {
     AccConfig(acc_config::Error),
 }
 
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct Bno055<I> {
     i2c: I,
     pub mode: BNO055OperationMode,
@@ -655,7 +660,7 @@ where
 }
 
 bitflags! {
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[cfg_attr(not(feature = "defmt-03"), derive(Debug, Clone, Copy, PartialEq, Eq))]
     pub struct BNO055AxisConfig: u8 {
         const AXIS_AS_X = 0b00;
         const AXIS_AS_Y = 0b01;
@@ -684,6 +689,7 @@ pub struct AxisRemap {
     z: BNO055AxisConfig,
 }
 
+#[derive(Debug)]
 pub struct AxisRemapBuilder {
     remap: AxisRemap,
 }
@@ -766,7 +772,7 @@ impl AxisRemapBuilder {
 }
 
 bitflags! {
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[cfg_attr(not(feature = "defmt-03"), derive(Debug, Clone, Copy, PartialEq, Eq))]
     pub struct BNO055AxisSign: u8 {
         const X_NEGATIVE = 0b100;
         const Y_NEGATIVE = 0b010;
@@ -775,7 +781,7 @@ bitflags! {
 }
 
 bitflags! {
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[cfg_attr(not(feature = "defmt-03"), derive(Debug, Clone, Copy, PartialEq, Eq))]
     pub struct BNO055SystemStatusCode: u8 {
         const SYSTEM_IDLE = 0;
         const SYSTEM_ERROR = 1;
@@ -789,7 +795,7 @@ bitflags! {
 
 bitflags! {
     /// Possible BNO055 errors.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[cfg_attr(not(feature = "defmt-03"), derive(Debug, Clone, Copy, PartialEq, Eq))]
     pub struct BNO055SystemErrorCode: u8 {
         const NONE = 0;
         const PERIPHERAL_INIT = 1;
@@ -807,7 +813,7 @@ bitflags! {
 
 bitflags! {
     /// BNO055 self-test status bit flags.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[cfg_attr(not(feature = "defmt-03"), derive(Debug, Clone, Copy, PartialEq, Eq))]
     pub struct BNO055SelfTestStatus: u8 {
         const ACC_OK = 0b0001;
         const MAG_OK = 0b0010;
@@ -817,6 +823,7 @@ bitflags! {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct BNO055SystemStatus {
     status: BNO055SystemStatusCode,
     selftest: Option<BNO055SelfTestStatus>,
@@ -824,6 +831,7 @@ pub struct BNO055SystemStatus {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct BNO055Revision {
     pub software: u16,
     pub bootloader: u8,
@@ -834,6 +842,7 @@ pub struct BNO055Revision {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[repr(C)]
 pub struct BNO055Calibration {
     pub acc_offset_x_lsb: u8,
@@ -892,7 +901,7 @@ pub struct BNO055CalibrationStatus {
 
 bitflags! {
     /// Possible BNO055 register map pages.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[cfg_attr(not(feature = "defmt-03"), derive(Debug, Clone, Copy, PartialEq, Eq))]
     pub struct BNO055RegisterPage: u8 {
         const PAGE_0 = 0;
         const PAGE_1 = 1;
@@ -901,7 +910,7 @@ bitflags! {
 
 bitflags! {
     /// Possible BNO055 power modes.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[cfg_attr(not(feature = "defmt-03"), derive(Debug, Clone, Copy, PartialEq, Eq))]
     pub struct BNO055PowerMode: u8 {
         const NORMAL = 0b00;
         const LOW_POWER = 0b01;
@@ -911,8 +920,7 @@ bitflags! {
 
 bitflags! {
     /// Possible BNO055 operation modes.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+    #[cfg_attr(not(feature = "defmt-03"), derive(Debug, Clone, Copy, PartialEq, Eq))]
     pub struct BNO055OperationMode: u8 {
         const CONFIG_MODE = 0b0000;
         const ACC_ONLY = 0b0001;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub use regs::BNO055_ID;
 
 /// All possible errors in this crate
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum Error<E> {
     /// I2C bus error
     I2c(E),
@@ -872,6 +873,7 @@ impl BNO055Calibration {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct BNO055CalibrationStatus {
     pub sys: u8,
     pub gyr: u8,
@@ -898,6 +900,7 @@ bitflags! {
 
 bitflags! {
     /// Possible BNO055 operation modes.
+    #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
     pub struct BNO055OperationMode: u8 {
         const CONFIG_MODE = 0b0000;
         const ACC_ONLY = 0b0001;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 #![doc(html_root_url = "https://docs.rs/bno055/0.3.3")]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-///! Bosch Sensortec BNO055 9-axis IMU sensor driver.
-///! Datasheet: https://ae-bst.resource.bosch.com/media/_tech/media/datasheets/BST-BNO055-DS000.pdf
+//! Bosch Sensortec BNO055 9-axis IMU sensor driver.
+//! Datasheet: https://ae-bst.resource.bosch.com/media/_tech/media/datasheets/BST-BNO055-DS000.pdf
 use embedded_hal::{
     delay::DelayNs,
     i2c::{I2c, SevenBitAddress},
@@ -668,6 +668,7 @@ bitflags! {
     }
 }
 
+#[allow(clippy::misnamed_getters)]
 impl AxisRemap {
     pub fn x(&self) -> BNO055AxisConfig {
         self.x
@@ -762,6 +763,7 @@ impl AxisRemapBuilder {
         self.remap.x == self.remap.y || self.remap.y == self.remap.z || self.remap.z == self.remap.x
     }
 
+    #[allow(clippy::result_unit_err)]
     pub fn build(self) -> Result<AxisRemap, ()> {
         if self.is_invalid() {
             Err(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc(html_root_url = "https://docs.rs/bno055/0.3.3")]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::bad_bit_mask)]
 
 //! Bosch Sensortec BNO055 9-axis IMU sensor driver.
 //! Datasheet: https://ae-bst.resource.bosch.com/media/_tech/media/datasheets/BST-BNO055-DS000.pdf


### PR DESCRIPTION
Something to note: `defmt` still uses `bitflags@1` which adds some derive macros when `bitflags!` macro is used. `defmt` also defines their own `bitflags!` macro to derive `Format` which leads to the `cfg_attr`ibutes when the `defmt-03` feature is **not** enabled