### PR TITLE
add note about I2C issues with certain microcontrollers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ so be careful that you're not enabling `serde`'s `std` feature by accident (see 
     // let delay = ...;
 
     // Init BNO055 IMU
-    let imu = bno055::Bno055::new(i2c);
+    let mut imu = bno055::Bno055::new(i2c);
 
     imu.init(&mut delay)?;
 
     // Enable 9-degrees-of-freedom sensor fusion mode with fast magnetometer calibration
-    imu.set_mode(bno055::BNO055OperationMode::NDOF)?;
+    imu.set_mode(bno055::BNO055OperationMode::NDOF, &mut delay)?;
 
     Ok(imu)
     ```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ Uses and re-exports [mint](https://crates.io/crates/mint)'s
 and [EulerAngles](https://docs.rs/mint/0.5.1/mint/struct.EulerAngles.html) for Euler angles
 and [Vector3](https://docs.rs/mint/0.5.1/mint/struct.Vector3.html) for sensor readings.
 
+## Important note on I2C issues
+As [noted e.g. by Adafruit](https://learn.adafruit.com/adafruit-bno055-absolute-orientation-sensor) the sensor has issues
+with its I2C implementation, which causes it to not work correctly with certain microcontrollers.
+
+This seems to be caused by clock stretching, thus running at lower I2C speeds and with increased I2C timeouts should
+resolve the issue.
+
 ## Feature flags
 
 ### `std`

--- a/README.md
+++ b/README.md
@@ -19,12 +19,19 @@ Uses and re-exports [mint](https://crates.io/crates/mint)'s
 and [EulerAngles](https://docs.rs/mint/0.5.1/mint/struct.EulerAngles.html) for Euler angles
 and [Vector3](https://docs.rs/mint/0.5.1/mint/struct.Vector3.html) for sensor readings.
 
-## Important note on I2C issues
+## Usage notes
+### Important note on I2C issues
 As [noted e.g. by Adafruit](https://learn.adafruit.com/adafruit-bno055-absolute-orientation-sensor) the sensor has issues
 with its I2C implementation, which causes it to not work correctly with certain microcontrollers.
 
 This seems to be caused by clock stretching, thus running at lower I2C speeds and with increased I2C timeouts should
 resolve the issue.
+
+### Initial startup delay
+The sensor has an initial startup time during which interaction with it will fail.
+As per [the documentation](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bno055-ds000.pdf)
+this is in the 400ms - 650ms range (consult chapter 1.2 / page 14 for further details).
+If your microcontroller is faster in starting up you might have to delay before talking to the sensor (or retry on failure).
 
 ## Feature flags
 


### PR DESCRIPTION
while i can use the sensor (& library) directly with my STM32F4 it doesn't work out of the box with my ESP32C6. after some digging & debugging i found https://github.com/esp-rs/esp-hal/issues/352 which explains this same problem (though for a BNO080) and the solution for it (increased timeout).

i think it's worth adding a note here as people will find this library more easily than the solution (esp. since Adafruit doesn't mention the solution and kind-of just says "meh, don't use it with those microcontrollers").